### PR TITLE
Fix symbol issue in Vivado 2018

### DIFF
--- a/picorv32_1.0/component.xml
+++ b/picorv32_1.0/component.xml
@@ -296,7 +296,7 @@
     <spirit:addressSpace>
       <spirit:name>M_AXI</spirit:name>
       <spirit:range spirit:format="long" spirit:resolve="dependent" spirit:dependency="pow(2,31+1)" spirit:minimum="0" spirit:maximum="4294967296" spirit:rangeType="long">4294967296</spirit:range>
-      <spirit:width spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.C_M_AXI_DATA_WIDTH&apos;)) - 1) + 1">32</spirit:width>
+      <spirit:width spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id('MODELPARAM_VALUE.C_M_AXI_DATA_WIDTH')) - 1) + 1">32</spirit:width>
     </spirit:addressSpace>
   </spirit:addressSpaces>
   <spirit:model>


### PR DESCRIPTION
Fix the following error in Vivado 2018.3 and newer versions
```
create_bd_cell -type ip -vlnv clifford.at:user:picorv32:1.0 picorv32_0
WARNING: [IP_Flow 19-3331] Invalid parameters found in dependency constraints of 'ADDRSPACE_WIDTH.M_AXI' 
WARNING: [IP_Flow 19-3331] Invalid parameters found in dependency constraints of 'ADDRSPACE_WIDTH.M_AXI' 
WARNING: [IP_Flow 19-3553] Error found in parameter dependencies in XGUI files. Invalid parameters found in dependency constraints of 'ADDRSPACE_WIDTH.M_AXI' 

ERROR: [IP_Flow 19-3428] Failed to create Customization object design_1_picorv32_0_0
CRITICAL WARNING: [IP_Flow 19-973] Failed to create IP instance 'design_1_picorv32_0_0'. Error during customization.
ERROR: [BD 41-1712] Create IP failed with errors
ERROR: [BD 5-7] Error: running create_bd_cell  -vlnv clifford.at:user:picorv32:1.0 -type ip -name picorv32_0 .
ERROR: [Common 17-39] 'create_bd_cell' failed due to earlier errors.
```